### PR TITLE
Fetch conference based on slug instead of name

### DIFF
--- a/lib/get_freaky/conference.rb
+++ b/lib/get_freaky/conference.rb
@@ -10,7 +10,8 @@ class Conference
   end
 
   def self.find(name)
-    response = get("/conferences/#{name}.json")
+    slug = create_slug(name)
+    response = get("/conferences/#{slug}.json")
     # TODO: I need to figure out a better way of dealing with 404 errors
     if response["status"] == 404
       NullConference.new("No conference was found with that name")
@@ -41,5 +42,13 @@ class Conference
 
   def valid?
     true
+  end
+
+  def self.create_slug(title)
+    title.
+      downcase.
+      # we cannot use slugify method below, one conference name has `:` char which must exist in url name (slug)
+      gsub(/[ ._]/, "-").
+      gsub(/([|])/) { |match| CGI.escape(match) }
   end
 end

--- a/test/lib/get_freaky/conference_test.rb
+++ b/test/lib/get_freaky/conference_test.rb
@@ -6,6 +6,11 @@ class TestConference < Minitest::Test
     assert_equal conf.name, 'GORUCO'
   end
 
+  def test_conference_find_existing_conf_name_with_special_chars
+    conf = Conference.find 'AWS re:Invent'
+    assert_equal conf.name, 'AWS re:Invent'
+  end
+
   def test_conference_find_bogus_conf
     conf = Conference.find('bogus')
     assert_equal conf.name, "Error: No conference was found with that name"


### PR DESCRIPTION
Many conference names contain spaces or different chars which should be converted to `-`.
Without this conversion it will be impossible to fetch conference based by original name.
